### PR TITLE
Improve mobile layout for hero and project sections

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -216,15 +216,17 @@ nav ul li a:hover {
 .hero_content {
   padding-left: 20px;
   color: white;
-  width: 450px;
+  max-width: 450px;
+  width: 100%;
 }
 .hero_content h1 {
-  font-size: 40px;
+  font-size: clamp(32px, 8vw, 40px);
   font-weight: 700;
   padding-bottom: 12px;
-  line-height: 40px;
+  line-height: 1.1;
 }
 .hero_content p {
+  font-size: clamp(14px, 4vw, 18px);
   padding-bottom: 16px;
   margin-left: 0;
   margin-right: 0;
@@ -265,12 +267,13 @@ nav ul li a:hover {
   width: 100vw;
 }
 .highlight_card {
-  width: 500px;
+  width: 100%;
+  max-width: 500px;
 }
 
 
 .highlight_card .card_img img {
-  width: 500px;
+  width: 100%;
   border-radius: 17px;
 }
 
@@ -655,6 +658,14 @@ footer ul li a {
 @media (max-width: 640px) {
   .hero_content {
     padding-right: 20px;
+    max-width: 100%;
+  }
+  .hero_content h1 {
+    font-size: 32px;
+    line-height: 34px;
+  }
+  .hero_content p {
+    font-size: 14px;
   }
   .highlight .upper_cont {
     padding: 0px 20px 60px 20px;
@@ -700,44 +711,50 @@ footer ul li a {
 }
 @media (max-width: 570px) {
   .highlight_card {
-    width: 400px;
+    max-width: 400px;
   }
   .highlight_card .card_img img {
-    width: 400px;
+    width: 100%;
   }
   .tour_container .iframe_container {
-    width: 400px;
+    width: 100%;
+    max-width: 400px;
   }
   .tour_container iframe {
-    width: 400px;
+    width: 100%;
+    max-width: 400px;
     height: 600px;
   }
   .car_tour{
-    width: 400px;
+    width: 100%;
+    max-width: 400px;
   }
   #map{
     height: 250px;
     width: 250px;
     padding-left: 20px;
   }
-  
+
 }
 @media (max-width: 450px) {
   .highlight_card {
-    width: 300px;
+    max-width: 300px;
   }
   .highlight_card .card_img img {
-    width: 300px;
+    width: 100%;
   }
   .tour_container .iframe_container {
-    width: 300px;
+    width: 100%;
+    max-width: 300px;
   }
   .tour_container iframe {
-    width: 300px;
+    width: 100%;
+    max-width: 300px;
     height: 550px;
   }
   .car_tour{
-    width: 300px;
+    width: 100%;
+    max-width: 300px;
   }
 }
 

--- a/assets/css/projects.css
+++ b/assets/css/projects.css
@@ -250,12 +250,14 @@ nav ul li a:hover {
     gap: 58px;
     padding-bottom: 40px;
   }
-  .projects_container iframe {
-    width: 500px;
-    height: 400px;
-  }
   .projects_container .projects_iframe_container {
-    width: 500px;
+    width: 100%;
+    max-width: 500px;
+    aspect-ratio: 5 / 4;
+  }
+  .projects_container iframe {
+    width: 100%;
+    height: 100%;
   }
   .projects_details {
     display: flex;
@@ -304,22 +306,13 @@ nav ul li a:hover {
     color: black;
   }
   
-  @media (max-width: 570px) {
-    .projects_container .projects_iframe_container {
-      width: 400px;
-    }
-    .projects_container iframe {
-      width: 400px;
-      height: 600px;
-    }
+@media (max-width: 570px) {
+  .projects_container .projects_iframe_container {
+    max-width: 400px;
   }
-  @media (max-width: 450px) {
-    .projects_container .projects_iframe_container {
-      width: 300px;
-    }
-    .projects_container iframe {
-      width: 300px;
-      height: 550px;
-    }
+}
+@media (max-width: 450px) {
+  .projects_container .projects_iframe_container {
+    max-width: 300px;
   }
-  
+}


### PR DESCRIPTION
## Summary
- Make hero area typography fluid with clamp-based sizes
- Swap fixed iframe heights for aspect-ratio containers and leaner media queries

## Testing
- `php -l index.php && php -l servicios-recorridos-virtuales.php && php -l proyectos.php`


------
https://chatgpt.com/codex/tasks/task_e_68c5bb968554832fa44c0f7cca138e67